### PR TITLE
Small fixes

### DIFF
--- a/include/dbat/utils.h
+++ b/include/dbat/utils.h
@@ -1231,7 +1231,10 @@ void send_to_outdoor(fmt::string_view format, Args&&... args) {
 
         for(auto i = descriptor_list; i; i = i->next) {
             if(STATE(i) != CON_PLAYING || !(i->character)) continue;
-            i->output += formatted_string;
+            //If the character's current room isn't set as indoors, then send the message
+            if (!(ROOM_FLAGGED((get_room(i->character)), ROOM_INDOORS))) {
+                i->output += formatted_string;
+            }
         }
     }
     catch(const std::exception &e) {

--- a/src/act.misc.cpp
+++ b/src/act.misc.cpp
@@ -4944,7 +4944,8 @@ ACMD(do_cook) {
             pass = true;
         }
         if (pass == true) {
-            if (skill < prob) {
+            //Calculate failure chance, above level 80 there is no chance to fail
+            if (80 + (skill / 2) < prob) {
                 act("@wYou screw up the preparation of the recipe and end up wasting the ingredients!@n", true, ch,
                     nullptr, nullptr, TO_CHAR);
                 act("@C$n@w starts to prepare some food, but ends up ruining the ingredients instead!@n", true, ch,
@@ -5072,13 +5073,14 @@ ACMD(do_cook) {
             act("@C$n@w carefully prepares some ingredients and starts cooking them. After a while of patience and skillful care $e succeeds in making @D'@C$p@D'@w!@n",
                 true, ch, meal, nullptr, TO_ROOM);
             improve_skill(ch, SKILL_COOKING, 0);
-
+            //Calculate psbonus and expbonus to add to the food, skill level is significantly important in both
+            float masterBonus = (skill == 100) ? 1.2 : 1;
             if (psbonus > 0) {
                 if (skill * 0.10 > 0)
-                    psbonus = (skill * 0.10) * psbonus;
+                    psbonus = (skill * 0.10) * psbonus * masterBonus;
             }
             if (expbonus > 0) {
-                expbonus = skill * expbonus;
+                expbonus = skill * expbonus * masterBonus;
             }
 
             GET_OBJ_VAL(meal, 1) = psbonus;

--- a/src/act.other.cpp
+++ b/src/act.other.cpp
@@ -8047,13 +8047,15 @@ ACMD(do_spar) {
     if (IS_NPC(ch)) {
         return;
     }
+    //Will return true when you have PLR_SPAR flagged
     if (ch->playerFlags.flip(PLR_SPAR).test(PLR_SPAR)) {
-        act("@wYou cease your sparring stance.@n", false, ch, nullptr, nullptr, TO_CHAR);
-        act("@C$n@w ceases $s sparring stance.@n", false, ch, nullptr, nullptr, TO_ROOM);
-    }
-    else {
         act("@wYou move into your sparring stance.@n", false, ch, nullptr, nullptr, TO_CHAR);
         act("@C$n@w moves into $s sparring stance.@n", false, ch, nullptr, nullptr, TO_ROOM);
+    }
+    else {
+        
+        act("@wYou cease your sparring stance.@n", false, ch, nullptr, nullptr, TO_CHAR);
+        act("@C$n@w ceases $s sparring stance.@n", false, ch, nullptr, nullptr, TO_ROOM);
     }
 }
 

--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -5836,7 +5836,7 @@ int handle_combo(struct char_data *ch, struct char_data *vict) {
         COMBHITS(ch) += 1;
         send_to_char(ch, "@D(@GC-c-combo Bonus @gx%d@G!@D)@C Combo FINISHED for massive damage@G!@n\r\n", COMBHITS(ch));
     } else if (COMBO(ch) != LASTATK(ch) && COMBO(ch) > -1) {
-        send_to_char(ch, "@GCombo failed! Try harder next time!@n\r\n");
+        send_to_char(ch, "@GCombo failed!@n\r\n");
         COMBO(ch) = -1;
         COMBHITS(ch) = 0;
         return 0;

--- a/src/fight.cpp
+++ b/src/fight.cpp
@@ -1696,7 +1696,7 @@ static void handle_corpse_condition(struct obj_data *corpse, struct char_data *c
 static void make_corpse(struct char_data *ch, struct char_data *tch) {
     struct obj_data *corpse, *o;
     struct obj_data *money;
-    struct obj_data *obj, *next_obj, *meat;
+    struct obj_data *obj, *next_obj;
     int i, x, y;
 
     corpse = create_obj();
@@ -1733,17 +1733,46 @@ static void make_corpse(struct char_data *ch, struct char_data *tch) {
         if (!IS_NPC(tch) && GET_SKILL(tch, SKILL_SURVIVAL)) {
             int skill = GET_SKILL(tch, SKILL_SURVIVAL);
             if (!IS_HUMANOID(ch) && PRF_FLAGGED(tch, PRF_CARVE) && axion_dice(0) < skill) {
-                send_to_char(tch, "The choice edible meat is preserved because of your skill.\r\n");
-                meat = read_object(1612, VIRTUAL);
-                obj_to_char(meat, ch);
-                char nick[MAX_INPUT_LENGTH], nick2[MAX_INPUT_LENGTH], nick3[MAX_INPUT_LENGTH];
-                sprintf(nick, "@RRaw %s@R Steak@n", GET_NAME(ch));
-                sprintf(nick2, "Raw %s Steak", ch->name);
-                sprintf(nick3, "@wA @Rraw %s@R steak@w is lying here@n", GET_NAME(ch));
-                meat->short_description = strdup(nick);
-                meat->name = strdup(nick2);
-                meat->room_description = strdup(nick3);
-                GET_OBJ_MATERIAL(meat) = 14;
+                bool chance = false;
+                int repeats = 0;
+
+                if (skill < 25) {
+                    chance = true;
+                }
+                else if (skill < 50) {
+                    repeats = 1;
+                }
+                else if (skill < 75) {
+                    chance = true;
+                    repeats = 1;
+                }
+                else if (skill < 100) {
+                    repeats = 2;
+                }
+                else if (skill == 100) {
+                    chance = true;
+                    repeats = 2;
+                }
+
+                if (chance && rand_number(1, 10) > 5) {
+                    repeats += 1;
+                }
+
+                for (int ind = 0; ind < repeats; ind++) {
+                    struct obj_data *meat;
+                    send_to_char(tch, "The choice edible meat is preserved because of your skill.\r\n");
+                    meat = read_object(1612, VIRTUAL);
+                    obj_to_char(meat, ch);
+                    char nick[MAX_INPUT_LENGTH], nick2[MAX_INPUT_LENGTH], nick3[MAX_INPUT_LENGTH];
+                    sprintf(nick, "@RRaw %s@R Steak@n", GET_NAME(ch));
+                    sprintf(nick2, "Raw %s Steak", ch->name);
+                    sprintf(nick3, "@wA @Rraw %s@R steak@w is lying here@n", GET_NAME(ch));
+                    meat->short_description = strdup(nick);
+                    meat->name = strdup(nick2);
+                    meat->room_description = strdup(nick3);
+                    GET_OBJ_MATERIAL(meat) = 14;
+                }
+
             }
         }
     }

--- a/src/medit.cpp
+++ b/src/medit.cpp
@@ -479,7 +479,7 @@ void medit_disp_menu(struct descriptor_data *d) {
                     "@gF@n) Armor Class: [@c%4d@n],  @gG@n) Exp:      [@c%" I64T "@n],  @gH@n) Gold:  [@c%8d@n]\r\n",
 
                     OLC_NUM(d), genders[(int) GET_SEX(mob)], GET_ALIAS(mob),
-                    GET_SDESC(mob), GET_LDESC(mob), GET_DDESC(mob), 0,
+                    GET_SDESC(mob), GET_LDESC(mob), GET_DDESC(mob), GET_LEVEL(mob),
                     GET_ALIGNMENT(mob), GET_FISHD(mob), GET_DAMAGE_MOD(mob),
                     GET_NDD(mob), GET_SDD(mob), GET_HIT(mob), (mob->getCurKI()),
                     (mob->getCurST()), GET_ARMOR(mob), GET_EXP(mob), GET_GOLD(mob)

--- a/src/medit.cpp
+++ b/src/medit.cpp
@@ -882,11 +882,14 @@ void medit_parse(struct descriptor_data *d, char *arg) {
             break;
 
         case MEDIT_CLASS:
-            if (!OLC_MOB(d)->chclass) {
-                OLC_MOB(d)->chclass = sensei::sensei_map[sensei::commoner];
-            };
-            /* Change size HP dice based on class choice. */
-            //GET_MANA(OLC_MOB(d)) = class_hit_die_size[GET_CLASS(OLC_MOB(d))];
+            //Check if the sensei requested exists
+            if (sensei::find_sensei_map_id(i, sensei::sensei_map) != nullptr) {
+                //Set the mob's Sensei to the chosen sensei
+                OLC_MOB(d)->chclass = sensei::find_sensei_map_id(i, sensei::sensei_map);
+            }
+            else {
+                write_to_output(d, "Couldn't find the requested Sensei!\r\n");
+            }
             break;
 
         case MEDIT_COPY:

--- a/src/spell_parser.cpp
+++ b/src/spell_parser.cpp
@@ -1270,7 +1270,7 @@ void mag_assign_spells() {
 
     spello(SKILL_GENIUS, "genius", 25, 10, 1, POS_STANDING,
            TAR_CHAR_ROOM | TAR_NOT_SELF, true, MAG_ACTION_FULL | MAG_AFFECTSV, MAGSAVE_FORT | MAGSAVE_NONE, 0,
-           "You am dumb dumbner now.",
+           "Your thoughts feel less cohesive.",
            2, SCHOOL_TRANSMUTATION, DOMAIN_UNDEFINED);
 
     spello(SKILL_FLEX, "flex", 25, 10, 1, POS_STANDING,


### PR DESCRIPTION
Overview:

- Cooking changed to have an 66% chance of success at a skill level of 1, increasing up to level 80 where the chance of failure Ceases. 20% bonus to xp and PS when cooked by someone with a skill level of 100.
- Food can now give XP even past level 100
- Throwing up from overeating has been removed in favour of a system when con contributes a greater capacity to eat before you are too full. Majin can still eat as much as they like.
- Survival cuts of meat are more reliable, levels under 25 have a chance of harvesting one, below 50 and you will always harvest one, below 75 you will harvest between one and two, below 99 you will definitely harvest three. At 100 you have a chance for a fourth.
- Some language has been reworked that stood out as slightly hostile
- Bug: Sparring Stances should now give the correct string
- Bug: Outdoor rooms should no longer get weather updates
- Bug: Medit should now show the correct mob level
- Bug: Medit should now be able to change sensei